### PR TITLE
BSC support (ChainID 56)

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -38,6 +38,7 @@ function getAddress(chainId: number): string {
 		1: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
 		4: '0x42ad527de7d4e9d9d011ac45b31d8551f8fe9821',
 		42: '0x2cc8688c5f75e365aaeeb4ea8d6a480405a48d2a',
+		56: '0xe21a5b299756ee452a6a871ff29852862fc99be9',
 		100: '0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a',
 		1337: '0x77dca2c955b15e9de4dbbcf1246b4b85b651e50e',
 	};


### PR DESCRIPTION
Tested working

```js
const provider = new ethers.providers.JsonRpcProvider( `https://bsc-dataseed1.ninicoin.io/` );
```