### PR TITLE
add arbitrum testnet entry

### DIFF
--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -98,6 +98,10 @@ function getMulticall(chainId: number): Multicall | null {
       address: '0x10126ceb60954bc35049f24e819a380c505f8a0f',
       block: 0,
     },
+    421611: {
+      address: '0x19a13f6121a435cAae168c3d11641CA59d338aA3',
+      block: 0,
+    },
     42262: {
       address: '0xAC84239C64D4E21c98C905Eca62af0b56017B8F6',
       block: 0,


### PR DESCRIPTION
### Pull request adding arbitrum testnet
Like mentioned in issue #88 
Pull request to add arbitrum testnet entry in `multicall.ts`

`0x19a13f6121a435cAae168c3d11641CA59d338aA3` [https://testnet.arbiscan.io/address/0x19a13f6121a435cAae168c3d11641CA59d338aA3](https://testnet.arbiscan.io/address/0x19a13f6121a435cAae168c3d11641CA59d338aA3)

### Some comments
We can see that an entry was already present in the `getMulticall3` method and i'm not sure if this has some kind of impact.

We can see that this address is linked on that method
```ts
const address = '0xca11bde05977b3631167028862be2a173976ca11';
```
And below arbitrum testnet:
```ts
421611: {
      address,
      block: 10228837,
},
```

If we look at arbiscan we can see a contract creation on that address  [https://testnet.arbiscan.io/address/0xca11bde05977b3631167028862be2a173976ca11](https://testnet.arbiscan.io/address/0xca11bde05977b3631167028862be2a173976ca11)

Feel free to modify if needed

