### PR TITLE
Match msg.sender to tx.origin

### DIFF
--- a/src/abi.ts
+++ b/src/abi.ts
@@ -7,7 +7,7 @@ type Params = any[];
 class Abi {
   static encode(
     name: string,
-    jsonInputs: JsonFragmentType[],
+    jsonInputs: readonly JsonFragmentType[],
     params: Params,
   ): string {
     const { params: inputs } = backfillParamNames(jsonInputs);
@@ -26,7 +26,7 @@ class Abi {
   }
 
   static encodeConstructor(
-    jsonInputs: JsonFragmentType[],
+    jsonInputs: readonly JsonFragmentType[],
     params: Params,
   ): string {
     const { params: inputs } = backfillParamNames(jsonInputs);
@@ -45,7 +45,7 @@ class Abi {
 
   static decode(
     name: string,
-    jsonOutputs: JsonFragmentType[],
+    jsonOutputs: readonly JsonFragmentType[],
     data: string,
   ): Result {
     const { params: outputs, generated } = backfillParamNames(jsonOutputs);
@@ -82,7 +82,7 @@ class Abi {
 // ABI doesn't enforce to specify param names
 // However, abi-coder requires names to parse the params.
 // Therefore, we "patch" the ABI by assigning unique param names.
-function backfillParamNames(jsonParams: JsonFragmentType[]): {
+function backfillParamNames(jsonParams: readonly JsonFragmentType[]): {
   params: JsonFragmentType[];
   generated: Set<string>;
 } {

--- a/src/call.ts
+++ b/src/call.ts
@@ -60,6 +60,7 @@ async function all<T>(
   });
   const overrides = {
     blockTag: block,
+    from: multicall?.address,
   };
   const response = contract
     ? await contract.aggregate(callRequests, overrides)
@@ -95,6 +96,7 @@ async function tryAll<T>(
   });
   const overrides = {
     blockTag: block,
+    from: multicall2?.address,
   };
   const response: CallResult[] = contract
     ? await contract.tryAggregate(false, callRequests, overrides)
@@ -140,6 +142,7 @@ async function tryEach<T>(
   });
   const overrides = {
     blockTag: block,
+    from: multicall3?.address,
   };
   const response: CallResult[] = contract
     ? await contract.aggregate3(callRequests, overrides)

--- a/src/call.ts
+++ b/src/call.ts
@@ -28,8 +28,8 @@ interface Call {
     address: string;
   };
   name: string;
-  inputs: JsonFragmentType[];
-  outputs: JsonFragmentType[];
+  inputs: readonly JsonFragmentType[];
+  outputs: readonly JsonFragmentType[];
   params: Params;
 }
 


### PR DESCRIPTION
Allows reading contract data with restricted access
Doesn't support calls on networks without deployments