### PR TITLE
Adds configurable multicall address in Provider.constructor

### DIFF
--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -1,5 +1,5 @@
-import { BaseProvider, Network } from '@ethersproject/providers';
-import { describe, test, expect } from 'vitest';
+import { BaseProvider, JsonRpcProvider, Network } from '@ethersproject/providers';
+import { describe, expect, test, vitest } from 'vitest';
 
 import Provider from '../src/provider';
 
@@ -29,5 +29,53 @@ describe('Provider', () => {
     expect(provider.all([])).rejects.toThrow();
     expect(provider.tryAll([])).rejects.toThrow();
     expect(provider.tryEach([], [])).rejects.toThrow();
+  });
+
+  test('adds multicall address manually', async () => {
+    const chainId = 0x72;
+    const provider = new Provider();
+    const errorMessage = 'Multicall contract is not available on this network.';
+    const providerExt = new Provider({
+      [chainId]: {
+        1: {
+          address: '0xC1a617f5d6bEE81c4677263f08D0c5d1757B7a3e',
+          block: 0,
+        },
+        2: {
+          address: '0xC1a617f5d6bEE81c4677263f08D0c5d1757B7a3e',
+          block: 0,
+        },
+        3: {
+          address: '0xC1a617f5d6bEE81c4677263f08D0c5d1757B7a3e',
+          block: 0,
+        },
+      }
+    });
+
+    await provider.init(new FakeProvider(chainId));
+
+    expect(() => provider.getEthBalance('')).toThrow(errorMessage);
+    expect(provider.all([])).rejects.toThrow();
+    expect(provider.tryAll([])).rejects.toThrow();
+    expect(provider.tryEach([], [])).rejects.toThrow();
+
+    const _warn = console.warn;
+
+    console.warn = vitest.fn();
+
+    await providerExt.init(
+      new JsonRpcProvider(
+        "https://coston2-api.flare.network/ext/C/rpc"
+      )
+    );
+
+    expect(() => providerExt.getEthBalance('')).not.toThrow();
+    expect(providerExt.all([])).not.rejects.toThrow();
+    expect(providerExt.tryAll([])).not.rejects.toThrow();
+    expect(providerExt.tryEach([], [])).not.rejects.toThrow();
+
+    expect(console.warn).not.toBeCalled();
+
+    console.warn = _warn;
   });
 });


### PR DESCRIPTION
Adds the capability to set multicall contracts addresses without updating the main repo each time.

This is useful for programmatic multicall address change or simply to avoid deploying to npm/gh because of new contract deployments.

#### How it works

While instancing the `Provider`, you can pass an optional argument which is a:

```ts
type AdditionalMulticallAddresses = Record<number, Partial<Record<1 | 2 | 3, Multicall>>>
```

The first `number` is the chainId, while the `1 | 2 | 3` in ` Partial<Record<1 | 2 | 3, Multicall>>` are the (optioanl) multicall contract addresses versions, with `Multicall` descriptor (`address` and `block`)

###### Example

```ts
const provider = new Provider({
    0x72: {
        3: {
          address: '0xC1a617f5d6bEE81c4677263f08D0c5d1757B7a3e',
          block: 0,
        },
     }
});

await providerExt.init(
    new JsonRpcProvider(
        "https://coston2-api.flare.network/ext/C/rpc"
    )
);

// providerExt.tryAll(calls)
```

