### PR TITLE
Adding Celo & Alfajores Multicall2 deployments 🟢 🟡 

### DIFF
--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -184,6 +184,14 @@ function getMulticall2(chainId: number): Multicall | null {
       address: '0x842eC2c7D803033Edf55E478F461FC547Bc54EB2',
       block: 0,
     },
+    42220: {
+      address: '0xE72f42c64EA3dc05D2D94F541C3a806fa161c49B',
+      block: 9325322,
+    },
+    44787: {
+      address: '0xDd488d424357F83B6Eb42900B65EB59CaFAdB43d',
+      block: 7881917,
+    },
     53935: {
       address: '0x5b24224dC16508DAD755756639E420817DD4c99E',
       block: 62,

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -189,8 +189,8 @@ function getMulticall2(chainId: number): Multicall | null {
       block: 9325322,
     },
     44787: {
-      address: '0xDd488d424357F83B6Eb42900B65EB59CaFAdB43d',
-      block: 7881917,
+      address: '0xA3A2E17933C0865534Ac7839F7a860E40C95D340',
+      block: 9082778,
     },
     53935: {
       address: '0x5b24224dC16508DAD755756639E420817DD4c99E',


### PR DESCRIPTION
Summary:
- As titled, this PR is seeking to add 2 new deployments to the `getMulticall2` method
- Verified code:
  https://explorer.celo.org/mainnet/address/0xE72f42c64EA3dc05D2D94F541C3a806fa161c49B/contracts 
  https://explorer.celo.org/alfajores/address/0xA3A2E17933C0865534Ac7839F7a860E40C95D340/transactions
- The expectation is that the `ethcall` npm package should then work when wrapped around providers instantiated on Celo & Alfajores RPC endpoints